### PR TITLE
fixed small typo in package.json line 2059

### DIFF
--- a/package.json
+++ b/package.json
@@ -2056,7 +2056,7 @@
 				},
 				"textPowerTools.customLocale": {
 					"type": "string",
-					"description": "Custom locale (eg. `en-US`, `hu-HU`) to use instead of system locale when running date amd time related comamnds."
+					"description": "Custom locale (eg. `en-US`, `hu-HU`) to use instead of system locale when running date and time related comamnds."
 				}
 			}
 		},


### PR DESCRIPTION
related to VSC extension Text Power Tools setting _Custom Locale_:
> Custom locale (eg. `en-US`, `hu-HU`) to use instead of system locale when running date amd time related comamnds.

Thanks for the extension!
